### PR TITLE
Improved Category Setting to be have two style

### DIFF
--- a/ExtraEnemyCustomization/Configs/CategoryConfig.cs
+++ b/ExtraEnemyCustomization/Configs/CategoryConfig.cs
@@ -7,22 +7,66 @@ namespace EECustom.Configs
 {
     public class CategoryConfig
     {
-        public CategoryDefinition[] Categories { get; set; } = new CategoryDefinition[0];
+        public string[] Categories { get; set; } = new string[0];
+        public IdWithCategories[] CategoryPair { get; set; } = new IdWithCategories[0];
+        public CategoryWithIds[] IdPair { get; set; } = new CategoryWithIds[0];
 
         private Dictionary<string, CategoryDefinition> CategoryCache = new Dictionary<string, CategoryDefinition>();
 
         internal void Cache()
         {
-            foreach(var category in Categories)
+            //Assign Category
+            foreach (var category in Categories)
             {
-                if (CategoryCache.ContainsKey(category.Name))
+                if (CategoryCache.ContainsKey(category.ToUpper()))
                 {
-                    Logger.Error($"Overlapping Category Found, Category Name: {category.Name}");
+                    Logger.Error($"Overlapping Category Found, Category Name: {category}");
                     continue;
                 }
 
-                CategoryCache.Add(category.Name, category);
-                Logger.Debug($"Category Initialized! '{category.Name}', ids: [{string.Join(", ", category.PersistentIDs)}]");
+                CategoryCache.Add(category.ToUpper(), new CategoryDefinition()
+                {  
+                    Name = category
+                });
+                Logger.Debug($"Category Defined! '{category}'");
+            }
+
+            //Id-Categories Pair
+            foreach (var categoryPair in CategoryPair)
+            {
+                foreach (var category in categoryPair.Categories)
+                {
+                    if (!CategoryCache.TryGetValue(category.ToUpper(), out var definition))
+                    {
+                        Logger.Error($"Unable to find Category: {category}");
+                        continue;
+                    }
+
+                    definition.AddEnemyID(categoryPair.PersistentID);
+                }
+                
+                Logger.Verbose($"Assign Categories to ID: '{categoryPair.PersistentID}', Categories: [{string.Join(", ", categoryPair.Categories)}]");
+            }
+
+            //Category-Ids Pair
+            foreach (var idPair in IdPair)
+            {
+                if (!CategoryCache.TryGetValue(idPair.Category.ToUpper(), out var definition))
+                {
+                    Logger.Error($"Unable to find Category: {idPair.Category}");
+                    continue;
+                }
+
+                definition.AddEnemyIDRange(idPair.PersistentIDs);
+                Logger.Verbose($"Assign Id to Category: '{idPair.Category}', ids: [{string.Join(", ", idPair.PersistentIDs)}]");
+            }
+
+            //Final Cache
+            foreach (var categoryCache in CategoryCache.Values)
+            {
+                categoryCache.CacheID();
+
+                Logger.Debug($"Category Initialized! '{categoryCache.Name}', ids: [{string.Join(", ", categoryCache.PersistentIDs)}]");
             }
         }
 
@@ -30,7 +74,7 @@ namespace EECustom.Configs
         {
             foreach(var category in categories)
             {
-                if (!CategoryCache.TryGetValue(category, out var categoryDef))
+                if (!CategoryCache.TryGetValue(category.ToUpper(), out var categoryDef))
                 {
                     Logger.Warning($"Unable to find Category with name: {category}");
                     continue;
@@ -50,7 +94,7 @@ namespace EECustom.Configs
             var result = true;
             foreach (var category in categories)
             {
-                if (!CategoryCache.TryGetValue(category, out var categoryDef))
+                if (!CategoryCache.TryGetValue(category.ToUpper(), out var categoryDef))
                 {
                     Logger.Warning($"Unable to find Category with name: {category}");
                     result = false;
@@ -68,9 +112,40 @@ namespace EECustom.Configs
         }
     }
 
+    public class IdWithCategories
+    {
+        public uint PersistentID { get; set; }
+        public string[] Categories { get; set; } = new string[0];
+    }
+    public class CategoryWithIds
+    {
+        public string Category { get; set; }
+        public uint[] PersistentIDs { get; set; } = new uint[0];
+    }
+
     public class CategoryDefinition
     {
         public string Name { get; set; }
-        public uint[] PersistentIDs { get; set; } = new uint[1] { 0u };
+        public uint[] PersistentIDs { get; private set; } = new uint[0];
+
+        public readonly List<uint> _PersistentIDs = new List<uint>();
+
+        public void AddEnemyIDRange(uint[] ids)
+        {
+            Array.ForEach(ids, (uint id) => { AddEnemyID(id); });
+        }
+
+        public void AddEnemyID(uint id)
+        {
+            if (!_PersistentIDs.Contains(id))
+            {
+                _PersistentIDs.Add(id);
+            } 
+        }
+
+        public void CacheID()
+        {
+            PersistentIDs = _PersistentIDs.ToArray();
+        }
     }
 }


### PR DESCRIPTION
```
{
	"Categories": [
		"Small",
		"Striker",
		"Shooter",
		"Scout",
		"Big",
		"Bullrush"
	],
	"CategoryPair": [
		{
			"PersistentID": 24, //Striker Hibernate
			"Categories": [
				"Small", "Striker"
			]
		}
	],
	"IdPair": [
		{
			"Category": "Small",
			"PersistentIDs": [
				24, //Striker Hibernate
				13, //Striker Wave
				21, //Shadow
				30, //Bullrush
				26, //Shooter Hibernate
				11 //Shooter Wave
			]
		},
		{
			"Category": "Striker",
			"PersistentIDs": [
				24,
				13,
				16,
				28,
				35
			]
		},
		{
			"Category": "Big",
			"PersistentIDs": [
				16, //Big Striker Wave
				39, //Big Striker Bullrush
				28, //Big Striker Hibernate
				35, //Big Striker Shadow
				18, //Big Shooter
				33 //Hybrid
			]
		},
		{
			"Category": "Bullrush",
			"PersistentIDs": [
				30, //Bullrush
				39 //Big Striker Bullrush
			]
		}
	]
}
```
now they could be work in two different method in same time
which allows more option depends on situation