### PR TITLE
Ability/ScoutScreamingCustom - And Slight change on FogSphereCustom

### DIFF
--- a/ExtraEnemyCustomization/Configs/Customizations/AbilityCustomConfig.cs
+++ b/ExtraEnemyCustomization/Configs/Customizations/AbilityCustomConfig.cs
@@ -16,7 +16,7 @@ namespace EECustom.Configs.Customizations
         public ExplosiveAttackCustom[] ExplosiveAttackCustom { get; set; } = new ExplosiveAttackCustom[0];
         public BleedAttackCustom[] BleedAttackCustom { get; set; } = new BleedAttackCustom[0];
         public DoorBreakerCustom[] DoorBreakerCustom { get; set; } = new DoorBreakerCustom[0];
-        public ScoutScreamingCustom[] ScoutScreamCustom { get; set; } = new ScoutScreamingCustom[0];
+        public ScoutScreamingCustom[] ScoutScreamingCustom { get; set; } = new ScoutScreamingCustom[0];
 
         public override EnemyCustomBase[] GetAllSettings()
         {
@@ -29,6 +29,7 @@ namespace EECustom.Configs.Customizations
             list.AddRange(ExplosiveAttackCustom);
             list.AddRange(BleedAttackCustom);
             list.AddRange(DoorBreakerCustom);
+            list.AddRange(ScoutScreamingCustom);
             return list.ToArray();
         }
     }

--- a/ExtraEnemyCustomization/Configs/Customizations/AbilityCustomConfig.cs
+++ b/ExtraEnemyCustomization/Configs/Customizations/AbilityCustomConfig.cs
@@ -16,6 +16,7 @@ namespace EECustom.Configs.Customizations
         public ExplosiveAttackCustom[] ExplosiveAttackCustom { get; set; } = new ExplosiveAttackCustom[0];
         public BleedAttackCustom[] BleedAttackCustom { get; set; } = new BleedAttackCustom[0];
         public DoorBreakerCustom[] DoorBreakerCustom { get; set; } = new DoorBreakerCustom[0];
+        public ScoutScreamingCustom[] ScoutScreamCustom { get; set; } = new ScoutScreamingCustom[0];
 
         public override EnemyCustomBase[] GetAllSettings()
         {

--- a/ExtraEnemyCustomization/Customizations/Abilities/FogSphereCustom.cs
+++ b/ExtraEnemyCustomization/Customizations/Abilities/FogSphereCustom.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using EECustom.Customizations.Shared;
 using EECustom.Extensions;
 using EECustom.Utils;
 using Enemies;
@@ -19,10 +20,7 @@ namespace EECustom.Customizations.Abilities
         public float DensityAmountMin { get; set; } = 0.0f;
         public float DensityAmountMax { get; set; } = 5.0f;
         public float Duration { get; set; } = 30.0f;
-        public bool EffectEnabled { get; set; } = false;
-        public eEffectVolumeContents EffectContents { get; set; } = eEffectVolumeContents.Infection;
-        public eEffectVolumeModification EffectModification { get; set; } = eEffectVolumeModification.Inflict;
-        public float EffectScale { get; set; } = 1f;
+        public EffectVolumeSetting EffectVolume { get; set; } = new EffectVolumeSetting();
 
         private readonly List<(EAB_FogSphere fogEab, GameObject originalPrefab)> _ChangedList = new List<(EAB_FogSphere, GameObject)>();
         
@@ -63,13 +61,11 @@ namespace EECustom.Customizations.Abilities
 
         public void OnSpawned(EnemyAgent agent)
         {
-            if (EffectEnabled)
+            if (EffectVolume.Enabled)
             {
                 var effectSetting = EnemyProperty<SphereEffectSetting>.RegisterOrGet(agent);
                 effectSetting.HandlerCount = 0;
-                effectSetting.EffectContents = EffectContents;
-                effectSetting.EffectModification = EffectModification;
-                effectSetting.EffectScale = EffectScale;
+                effectSetting.Setting = EffectVolume;
             }
         }
     }
@@ -77,8 +73,6 @@ namespace EECustom.Customizations.Abilities
     public class SphereEffectSetting
     {
         public int HandlerCount = 0;
-        public eEffectVolumeContents EffectContents = eEffectVolumeContents.Infection;
-        public eEffectVolumeModification EffectModification = eEffectVolumeModification.Inflict;
-        public float EffectScale = 1.0f;
+        public EffectVolumeSetting Setting;
     }
 }

--- a/ExtraEnemyCustomization/Customizations/Abilities/Handlers/ScoutEffectFogSphereHandler.cs
+++ b/ExtraEnemyCustomization/Customizations/Abilities/Handlers/ScoutEffectFogSphereHandler.cs
@@ -1,0 +1,46 @@
+﻿using Enemies;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace EECustom.Customizations.Abilities.Handlers
+{
+    public class ScoutEffectFogSphereHandler : MonoBehaviour
+    {
+        public ES_ScoutScream ScoutScream;
+        public EV_Sphere EVSphere;
+
+        private float _updateTimer = 0.0f;
+
+        public ScoutEffectFogSphereHandler(IntPtr ptr) : base(ptr)
+        {
+        }
+
+        private void Update()
+        {
+            if (ScoutScream.m_fogSphereAdd != null && _updateTimer < Clock.Time)
+            {
+                if (ScoutScream.m_fogSphereAdd.IsAllocated)
+                {
+                    var sphere = ScoutScream.m_fogSphereAdd.m_sphere;
+                    var range = Mathf.Sqrt(1.0f / sphere.m_data.invRangeSqr);
+                    EVSphere.minRadius = range * 0.8f;
+                    EVSphere.maxRadius = range;
+                    EVSphere.position = ScoutScream.m_fogSphereAdd.m_sphere.m_data.position;
+                    _updateTimer = Clock.Time + 0.1f;
+                }
+                else
+                {
+                    EVSphere.minRadius = 0.0f;
+                    EVSphere.maxRadius = 0.0f;
+                }
+            }
+        }
+
+        private void OnDestroy()
+        {
+            EffectVolumeManager.UnregisterVolume(EVSphere);
+        }
+    }
+}

--- a/ExtraEnemyCustomization/Customizations/Abilities/Handlers/ScoutFogSphereHandler.cs
+++ b/ExtraEnemyCustomization/Customizations/Abilities/Handlers/ScoutFogSphereHandler.cs
@@ -6,20 +6,32 @@ using UnityEngine;
 
 namespace EECustom.Customizations.Abilities.Handlers
 {
-    public class ScoutEffectFogSphereHandler : MonoBehaviour
+    public class ScoutFogSphereHandler : MonoBehaviour
     {
+        public Color FogColor;
+        public float FogIntensity;
         public ES_ScoutScream ScoutScream;
-        public EV_Sphere EVSphere;
+        public EV_Sphere EVSphere = null;
 
         private float _updateTimer = 0.0f;
+        private bool _isColorSet = false;
 
-        public ScoutEffectFogSphereHandler(IntPtr ptr) : base(ptr)
+        public ScoutFogSphereHandler(IntPtr ptr) : base(ptr)
         {
         }
 
         private void Update()
         {
-            if (ScoutScream.m_fogSphereAdd != null && _updateTimer < Clock.Time)
+            if (ScoutScream.m_fogSphereAdd == null)
+                return;
+
+            if (!_isColorSet)
+            {
+                ScoutScream.m_fogSphereAdd.SetRadiance(FogColor, FogIntensity);
+                _isColorSet = true;
+            }
+
+            if (EVSphere != null && _updateTimer < Clock.Time)
             {
                 if (ScoutScream.m_fogSphereAdd.IsAllocated)
                 {
@@ -40,7 +52,8 @@ namespace EECustom.Customizations.Abilities.Handlers
 
         private void OnDestroy()
         {
-            EffectVolumeManager.UnregisterVolume(EVSphere);
+            if (EVSphere != null)
+                EffectVolumeManager.UnregisterVolume(EVSphere);
         }
     }
 }

--- a/ExtraEnemyCustomization/Customizations/Abilities/Inject/Inject_EAB_FogSphere.cs
+++ b/ExtraEnemyCustomization/Customizations/Abilities/Inject/Inject_EAB_FogSphere.cs
@@ -34,16 +34,7 @@ namespace EECustom.Customizations.Abilities.Inject
 
             var effectHandler = handler.gameObject.AddComponent<EffectFogSphereHandler>();
             effectHandler.Handler = handler;
-            effectHandler.EVSphere = new EV_Sphere()
-            {
-                position = handler.transform.position,
-                minRadius = 0.0f,
-                maxRadius = 0.0f,
-                modificationScale = effectSetting.EffectScale,
-                invert = true,
-                contents = effectSetting.EffectContents,
-                modification = effectSetting.EffectModification
-            };
+            effectHandler.EVSphere = effectSetting.Setting.CreateSphere(handler.transform.position, 0.0f, 0.0f);
             EffectVolumeManager.RegisterVolume(effectHandler.EVSphere);
         }
     }

--- a/ExtraEnemyCustomization/Customizations/Abilities/ScoutScreamingCustom.cs
+++ b/ExtraEnemyCustomization/Customizations/Abilities/ScoutScreamingCustom.cs
@@ -1,0 +1,48 @@
+﻿using EECustom.Customizations.Abilities.Handlers;
+using EECustom.Customizations.Shared;
+using EECustom.Events;
+using Enemies;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace EECustom.Customizations.Abilities
+{
+    public class ScoutScreamingCustom : EnemyCustomBase, IEnemySpawnedEvent
+    {
+        private readonly static Color DefaultChargeupColor = ES_ScoutScream.s_screamChargeupColor;
+
+        public Color ChargeupColor { get; set; } = new Color(0f, 1f, 0.8f, 1f) * 2f;
+        public Color FogColor { get; set; } = new Color(0f, 1f, 0.8f, 1f) * 20f;
+        public float FogIntensity { get; set; } = 1.0f;
+        public EffectVolumeSetting EffectVolume { get; set; } = new EffectVolumeSetting();
+
+        public override string GetProcessName()
+        {
+            return "ScoutScreaming";
+        }
+
+        public void OnSpawned(EnemyAgent agent)
+        {
+            EnemyGlowEvents.RegisterOnGlow(agent, OnGlow);
+
+            if (EffectVolume.Enabled)
+            {
+                var handler = agent.gameObject.AddComponent<ScoutEffectFogSphereHandler>();
+                handler.EVSphere = EffectVolume.CreateSphere(agent.transform.position, 0.0f, 0.0f);
+                handler.ScoutScream = agent.Locomotion.ScoutScream;
+            }
+        }
+
+        public Color OnGlow(EnemyAgent agent, Color color, Vector4 location)
+        {
+            if (color == DefaultChargeupColor)
+            {
+                return ChargeupColor;
+            }
+
+            return color;
+        }
+    }
+}

--- a/ExtraEnemyCustomization/Customizations/Abilities/ScoutScreamingCustom.cs
+++ b/ExtraEnemyCustomization/Customizations/Abilities/ScoutScreamingCustom.cs
@@ -32,6 +32,7 @@ namespace EECustom.Customizations.Abilities
                 var handler = agent.gameObject.AddComponent<ScoutEffectFogSphereHandler>();
                 handler.EVSphere = EffectVolume.CreateSphere(agent.transform.position, 0.0f, 0.0f);
                 handler.ScoutScream = agent.Locomotion.ScoutScream;
+                EffectVolumeManager.RegisterVolume(handler.EVSphere);
             }
         }
 

--- a/ExtraEnemyCustomization/Customizations/Abilities/ScoutScreamingCustom.cs
+++ b/ExtraEnemyCustomization/Customizations/Abilities/ScoutScreamingCustom.cs
@@ -27,11 +27,13 @@ namespace EECustom.Customizations.Abilities
         {
             EnemyGlowEvents.RegisterOnGlow(agent, OnGlow);
 
+
+            var handler = agent.gameObject.AddComponent<ScoutFogSphereHandler>();
+            handler.ScoutScream = agent.Locomotion.ScoutScream;
+
             if (EffectVolume.Enabled)
             {
-                var handler = agent.gameObject.AddComponent<ScoutEffectFogSphereHandler>();
                 handler.EVSphere = EffectVolume.CreateSphere(agent.transform.position, 0.0f, 0.0f);
-                handler.ScoutScream = agent.Locomotion.ScoutScream;
                 EffectVolumeManager.RegisterVolume(handler.EVSphere);
             }
         }

--- a/ExtraEnemyCustomization/Customizations/Abilities/ScoutScreamingCustom.cs
+++ b/ExtraEnemyCustomization/Customizations/Abilities/ScoutScreamingCustom.cs
@@ -30,6 +30,8 @@ namespace EECustom.Customizations.Abilities
 
             var handler = agent.gameObject.AddComponent<ScoutFogSphereHandler>();
             handler.ScoutScream = agent.Locomotion.ScoutScream;
+            handler.FogColor = FogColor;
+            handler.FogIntensity = FogIntensity;
 
             if (EffectVolume.Enabled)
             {

--- a/ExtraEnemyCustomization/Customizations/Models/GlowCustom.cs
+++ b/ExtraEnemyCustomization/Customizations/Models/GlowCustom.cs
@@ -1,5 +1,4 @@
-﻿using EECustom.Customizations.Models.Inject;
-using EECustom.Customizations.Models.Handlers;
+﻿using EECustom.Customizations.Models.Handlers;
 using EECustom.Events;
 using Enemies;
 using System;
@@ -73,7 +72,7 @@ namespace EECustom.Customizations.Models
                 }
             }
 
-            GlowEvents.RegisterOnGlow(agent, OnGlow);
+            EnemyGlowEvents.RegisterOnGlow(agent, OnGlow);
 
             //And this is static LMAO
             //ES_HibernateWakeUp.m_propagatedWakeupColor = PropagateWakeupColor

--- a/ExtraEnemyCustomization/Customizations/Models/ScannerCustom.cs
+++ b/ExtraEnemyCustomization/Customizations/Models/ScannerCustom.cs
@@ -1,5 +1,4 @@
-﻿using EECustom.Customizations.Models.Inject;
-using EECustom.Customizations.Models.Handlers;
+﻿using EECustom.Customizations.Models.Handlers;
 using EECustom.Events;
 using Enemies;
 using System;

--- a/ExtraEnemyCustomization/Customizations/Shared/EffectVolumeSetting.cs
+++ b/ExtraEnemyCustomization/Customizations/Shared/EffectVolumeSetting.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace EECustom.Customizations.Shared
+{
+    public class EffectVolumeSetting
+    {
+        public bool Enabled { get; set; } = false;
+        public eEffectVolumeContents Contents { get; set; } = eEffectVolumeContents.Infection;
+        public eEffectVolumeModification Modification { get; set; } = eEffectVolumeModification.Inflict;
+        public float Scale { get; set; } = 1f;
+
+        public EV_Sphere CreateSphere(Vector3 position, float minRadius, float maxRadius)
+        {
+            return new EV_Sphere()
+            {
+                position = position,
+                minRadius = minRadius,
+                maxRadius = maxRadius,
+                modificationScale = Scale,
+                invert = true,
+                contents = Contents,
+                modification = Modification
+            };
+        }
+    }
+}

--- a/ExtraEnemyCustomization/EntryPoint.cs
+++ b/ExtraEnemyCustomization/EntryPoint.cs
@@ -40,6 +40,7 @@ namespace EECustom
             ClassInjector.RegisterTypeInIl2Cpp<ExplosiveProjectileHandler>();
             ClassInjector.RegisterTypeInIl2Cpp<BleedingHandler>();
             ClassInjector.RegisterTypeInIl2Cpp<EffectFogSphereHandler>();
+            ClassInjector.RegisterTypeInIl2Cpp<ScoutEffectFogSphereHandler>();
 
             Logger.LogInstance = Log;
 

--- a/ExtraEnemyCustomization/EntryPoint.cs
+++ b/ExtraEnemyCustomization/EntryPoint.cs
@@ -40,7 +40,7 @@ namespace EECustom
             ClassInjector.RegisterTypeInIl2Cpp<ExplosiveProjectileHandler>();
             ClassInjector.RegisterTypeInIl2Cpp<BleedingHandler>();
             ClassInjector.RegisterTypeInIl2Cpp<EffectFogSphereHandler>();
-            ClassInjector.RegisterTypeInIl2Cpp<ScoutEffectFogSphereHandler>();
+            ClassInjector.RegisterTypeInIl2Cpp<ScoutFogSphereHandler>();
 
             Logger.LogInstance = Log;
 

--- a/ExtraEnemyCustomization/Events/EnemyGlowEvents.cs
+++ b/ExtraEnemyCustomization/Events/EnemyGlowEvents.cs
@@ -4,9 +4,9 @@ using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
 
-namespace EECustom.Customizations.Models.Inject
+namespace EECustom.Events
 {
-    public class GlowEvents
+    public class EnemyGlowEvents
     {
         private static Dictionary<ushort, Func<EnemyAgent, Color, Vector4, Color>> OnGlow = new Dictionary<ushort, Func<EnemyAgent, Color, Vector4, Color>>();
 

--- a/ExtraEnemyCustomization/Events/Inject/Inject_EnemyAppearance_InterpolateGlows.cs
+++ b/ExtraEnemyCustomization/Events/Inject/Inject_EnemyAppearance_InterpolateGlows.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
 
-namespace EECustom.Customizations.Models.Inject
+namespace EECustom.Events.Inject
 {
     [HarmonyPatch(typeof(EnemyAppearance))]
     class Inject_EnemyAppearance_InterpolateGlows
@@ -14,7 +14,7 @@ namespace EECustom.Customizations.Models.Inject
         [HarmonyWrapSafe]
         static void Pre_InterpolateGlow(ref Color col, Vector4 pos, float transitionTime, EnemyAppearance __instance)
         {
-            col = GlowEvents.FireEvent(__instance.m_owner, col, pos);
+            col = EnemyGlowEvents.FireEvent(__instance.m_owner, col, pos);
         }
     }
 }

--- a/ExtraEnemyCustomization/Utils/ColorConverter.cs
+++ b/ExtraEnemyCustomization/Utils/ColorConverter.cs
@@ -59,11 +59,62 @@ namespace EECustom.Utils
                     {
                         return color;
                     }
+
+                    if (TryParseColor(strValue, out color))
+                    {
+                        return color;
+                    }
                     throw new JsonException($"Color format is not right: {strValue}");
 
                 default:
                     throw new JsonException($"ColorJson type: {reader.TokenType} is not implemented!");
             }
+        }
+
+        private bool TryParseColor(string input, out Color color)
+        {
+            input = input.Trim().Trim('(',')');
+
+            if (!input.Contains(",", StringComparison.Ordinal))
+            {
+                color = Color.clear;
+                return false;
+            }
+
+            var split = input.Split(",");
+            if (split.Length != 3 && split.Length != 4)
+            {
+                color = Color.clear;
+                return false;
+            }
+
+            if (!float.TryParse(split[0].Trim(), out var r))
+            {
+                color = Color.clear;
+                return false;
+            }
+
+            if (!float.TryParse(split[1].Trim(), out var g))
+            {
+                color = Color.clear;
+                return false;
+            }
+
+            if (!float.TryParse(split[2].Trim(), out var b))
+            {
+                color = Color.clear;
+                return false;
+            }
+
+            var a = 1.0f;
+            if (split.Length == 4 && !float.TryParse(split[3].Trim(), out a))
+            {
+                color = Color.clear;
+                return false;
+            }
+
+            color = new Color(r, g, b, a);
+            return true;
         }
 
         public override void Write(Utf8JsonWriter writer, Color value, JsonSerializerOptions options)


### PR DESCRIPTION
Ability/ScoutScreamingCustom
```
	"ScoutScreamingCustom": [
		{
			"Enabled": true,
			"DebugName": "For Scout",
			"Target": {
				"Mode": "CategoryAny", //CategoryAll
				"persistentIDs": [],
				"nameParam": "",
				"nameIgnoreCase": true,
				"categories": [
					"Scout"
				]
			},
			"ChargeupColor": "red",
			"FogColor": "red",
			"FogIntensity": 1.0,
			"EffectVolume": {
				"Enabled": true,
				"Contents": "Infection",
				"Modification": "Inflict",
				"Scale": 0.1
			}
		}
	]
```

Old FogSphere Config
```
"FogSphereCustom": [
		{
			"Enabled": true, //You can check first item of Model.json if you have no idea with this formatting
			"DebugName": "BirtherFog_InfectionWave",
			"Target": {
......
			},
......
			"EffectEnabled": true,
			"EffectContents": "Infection",
			"EffectModification": "Inflict",
			"EffectScale": 0.1
		}
	],
```

New FogSphere Config
```
	"FogSphereCustom": [
		{
			"Enabled": true, //You can check first item of Model.json if you have no idea with this formatting
			"DebugName": "BirtherFog_InfectionWave",
			"Target": {
.......
			},
.......
			"EffectVolume": {
				"Enabled": true,
				"Contents": "Infection",
				"Modification": "Inflict",
				"Scale": 0.1
			}
			
		}
	],
```

This PR also allows ColorConverter a new format:
```
"Color": "(1.0, 1.0, 0.0, 1.0)"
"Color": "1.0, 1.0, 0.0, 1.0"
"Color": "(1.0 , 1.0 , 0.0 , 1.0)" //Anything you want
```