### PR TITLE
Striker attack animation speed now adjusts with actual attack timing

### DIFF
--- a/ExtraEnemyCustomization/EnemyCustomizations/Models/AnimHandleCustom.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Models/AnimHandleCustom.cs
@@ -1,9 +1,5 @@
 ﻿using EEC.Utils.Json.Elements;
 using Enemies;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Text.Json.Serialization;
 using static Enemies.EnemyLocomotion;
 
 namespace EEC.EnemyCustomizations.Models

--- a/ExtraEnemyCustomization/EnemyCustomizations/Models/AnimHandleCustom.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Models/AnimHandleCustom.cs
@@ -3,6 +3,7 @@ using Enemies;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Text.Json.Serialization;
 using static Enemies.EnemyLocomotion;
 
 namespace EEC.EnemyCustomizations.Models
@@ -48,6 +49,10 @@ namespace EEC.EnemyCustomizations.Models
             handle.ClimbSpeed = ClimbSpeed.GetAbsValue(handle.ClimbSpeed);
             handle.MeleeAttackFwd = MeleeAttackFwd.GetData(handle.MeleeAttackFwd);
             handle.MeleeAttackBwd = MeleeAttackBwd.GetData(handle.MeleeAttackBwd);
+
+            var setting = agent.RegisterOrGetProperty<TentacleAttackSpeedProperty>();
+            setting.TentacleAttackSpeedAdjustmentMult = agent.Locomotion.AnimHandle.TentacleAttackWindUpLen / handle.TentacleAttackWindUpLen;
+
             agent.Locomotion.AnimHandle = handle;
         }
     }
@@ -70,5 +75,10 @@ namespace EEC.EnemyCustomizations.Models
                 SFXId = ChangeSFX ? SFXId : original.SFXId
             };
         }
+    }
+
+    internal sealed class TentacleAttackSpeedProperty
+    {
+        public float TentacleAttackSpeedAdjustmentMult;
     }
 }

--- a/ExtraEnemyCustomization/EnemyCustomizations/Models/Inject/Inject_ES_EnemyAttackBase.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Models/Inject/Inject_ES_EnemyAttackBase.cs
@@ -1,21 +1,14 @@
 ﻿using Enemies;
 using HarmonyLib;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using EEC.Managers;
-using System.Linq;
-using EEC.EnemyCustomizations.Models;
-using EEC.Configs.Customizations;
-using EEC.API;
 
-namespace EEC.Patches
+namespace EEC.EnemyCustomizations.Models.Inject
 {
     [HarmonyPatch(typeof(ES_EnemyAttackBase))]
-    internal class TentacleAttackPatches // Need to know where to move this
+    internal static class Inject_ES_EnemyAttackBase
     {
         [HarmonyPatch(nameof(ES_EnemyAttackBase.DoStartAttack))]
         [HarmonyPrefix]
+        [HarmonyWrapSafe]
         public static void OnStartAttack(ES_EnemyAttackBase __instance)
         {
             if (__instance.m_enemyAgent.TryGetProperty<TentacleAttackSpeedProperty>(out var attackSpeedProperty))
@@ -29,6 +22,7 @@ namespace EEC.Patches
 
         [HarmonyPatch(nameof(ES_EnemyAttackBase.SyncExit))]
         [HarmonyPrefix]
+        [HarmonyWrapSafe]
         public static void OnEndAttack(ES_EnemyAttackBase __instance)
         {
             if (__instance.m_enemyAgent.TryGetProperty<TentacleAttackSpeedProperty>(out var attackSpeedProperty))

--- a/ExtraEnemyCustomization/Patches/TentacleAttackPatches.cs
+++ b/ExtraEnemyCustomization/Patches/TentacleAttackPatches.cs
@@ -1,0 +1,40 @@
+﻿using Enemies;
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using EEC.Managers;
+using System.Linq;
+using EEC.EnemyCustomizations.Models;
+using EEC.Configs.Customizations;
+using EEC.API;
+
+namespace EEC.Patches
+{
+    [HarmonyPatch(typeof(ES_EnemyAttackBase))]
+    internal class TentacleAttackPatches // Need to know where to move this
+    {
+        [HarmonyPatch(nameof(ES_EnemyAttackBase.DoStartAttack))]
+        [HarmonyPrefix]
+        public static void OnStartAttack(ES_EnemyAttackBase __instance)
+        {
+            if (__instance.m_enemyAgent.TryGetProperty<TentacleAttackSpeedProperty>(out var attackSpeedProperty))
+            {
+                __instance.m_locomotion.m_animator.speed *= attackSpeedProperty.TentacleAttackSpeedAdjustmentMult;
+            }
+
+            if (!SNetwork.SNet.IsMaster) // bug fix for clients not seeing tentacles
+                __instance.m_attackWindupDuration = __instance.m_enemyAgent.Locomotion.AnimHandle.TentacleAttackWindUpLen / __instance.m_enemyAgent.Locomotion.AnimSpeedOrg;
+        }
+
+        [HarmonyPatch(nameof(ES_EnemyAttackBase.SyncExit))]
+        [HarmonyPrefix]
+        public static void OnEndAttack(ES_EnemyAttackBase __instance)
+        {
+            if (__instance.m_enemyAgent.TryGetProperty<TentacleAttackSpeedProperty>(out var attackSpeedProperty))
+            {
+                __instance.m_locomotion.m_animator.speed /= attackSpeedProperty.TentacleAttackSpeedAdjustmentMult;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Requires client test.

TentacleAttackWindUpLen now adjusts not only attack timing, but animation speed to match.
Additionally fixes a base game bug where clients don't see tentacles.