### PR TITLE
Transition to .NET 6

### DIFF
--- a/ExtraEnemyCustomization/CustomAbilities/Bleed/Handlers/BleedHandler.cs
+++ b/ExtraEnemyCustomization/CustomAbilities/Bleed/Handlers/BleedHandler.cs
@@ -2,10 +2,10 @@
 using EEC.CustomAbilities.Bleed.Inject;
 using EEC.Utils;
 using EEC.Utils.Unity;
+using Il2CppInterop.Runtime.Attributes;
 using Player;
 using System;
 using System.Collections;
-using UnhollowerBaseLib.Attributes;
 using UnityEngine;
 
 namespace EEC.CustomAbilities.Bleed.Handlers

--- a/ExtraEnemyCustomization/CustomAbilities/EMP/EMPController.cs
+++ b/ExtraEnemyCustomization/CustomAbilities/EMP/EMPController.cs
@@ -1,5 +1,5 @@
 ﻿using EEC.Attributes;
-using UnhollowerBaseLib.Attributes;
+using Il2CppInterop.Runtime.Attributes;
 using UnityEngine;
 
 namespace EEC.CustomAbilities.EMP

--- a/ExtraEnemyCustomization/EnemyCustomizations/Abilities/Handlers/HealthRegenHandler.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Abilities/Handlers/HealthRegenHandler.cs
@@ -3,8 +3,8 @@ using EEC.Attributes;
 using EEC.Events;
 using EEC.Utils.Unity;
 using Enemies;
+using Il2CppInterop.Runtime.Attributes;
 using SNetwork;
-using UnhollowerBaseLib.Attributes;
 using UnityEngine;
 
 namespace EEC.EnemyCustomizations.Abilities.Handlers

--- a/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/SpawnWaveAbility.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/EnemyAbilities/Abilities/SpawnWaveAbility.cs
@@ -23,7 +23,7 @@
                 out _,
                 Ability.SpawnType,
                 Ability.SpawnDelay,
-                Ability.PlayDistantRoar);
+                playScreamOnSpawn: Ability.PlayDistantRoar);
             DoExit();
         }
     }

--- a/ExtraEnemyCustomization/EnemyCustomizations/Models/Handlers/MarkerTextHandler.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Models/Handlers/MarkerTextHandler.cs
@@ -1,11 +1,11 @@
 ﻿using EEC.Attributes;
 using EEC.Utils.Unity;
 using Enemies;
+using Il2CppInterop.Runtime.Attributes;
 using System;
 using System.Collections;
 using System.Linq;
 using System.Text;
-using UnhollowerBaseLib.Attributes;
 using UnityEngine;
 
 namespace EEC.EnemyCustomizations.Models.Handlers

--- a/ExtraEnemyCustomization/EnemyCustomizations/Models/Handlers/ScannerHandler.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Models/Handlers/ScannerHandler.cs
@@ -2,8 +2,8 @@
 using EEC.Attributes;
 using EEC.Utils.Unity;
 using Enemies;
+using Il2CppInterop.Runtime.Attributes;
 using System.Collections;
-using UnhollowerBaseLib.Attributes;
 using UnityEngine;
 
 namespace EEC.EnemyCustomizations.Models.Handlers

--- a/ExtraEnemyCustomization/EnemyCustomizations/Models/Handlers/SilhouetteHandler.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Models/Handlers/SilhouetteHandler.cs
@@ -1,7 +1,7 @@
 ﻿using EEC.Attributes;
 using EEC.Events;
 using Enemies;
-using UnhollowerBaseLib.Attributes;
+using Il2CppInterop.Runtime.Attributes;
 using UnityEngine;
 using UnityEngine.Rendering;
 

--- a/ExtraEnemyCustomization/EnemyCustomizations/Strikers/StrikerTentacleCustom.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Strikers/StrikerTentacleCustom.cs
@@ -1,6 +1,7 @@
 ﻿using EEC.Utils.Json.Elements;
 using Enemies;
 using GameData;
+using Il2CppInterop.Runtime;
 using System;
 
 namespace EEC.EnemyCustomizations.Strikers
@@ -38,8 +39,8 @@ namespace EEC.EnemyCustomizations.Strikers
                 if (isSettingEnabled)
                 {
                     var setting = TentacleSettings[i % TentacleSettings.Length];
-                    tentacle.m_easingIn = setting.GetInEaseFunction();
-                    tentacle.m_easingOut = setting.GetOutEaseFunction();
+                    tentacle.m_easingIn = DelegateSupport.ConvertDelegate<DelEasingFunction>(setting.GetInEaseFunction());
+                    tentacle.m_easingOut = DelegateSupport.ConvertDelegate<DelEasingFunction>(setting.GetOutEaseFunction());
                     tentacle.m_attackInDuration = setting.InDuration.GetAbsValue(tentacle.m_attackInDuration);
                     tentacle.m_attackOutDuration = setting.OutDuration.GetAbsValue(tentacle.m_attackOutDuration);
                     tentacle.m_attackHangDuration = setting.HangDuration.GetAbsValue(tentacle.m_attackHangDuration);

--- a/ExtraEnemyCustomization/EntryPoint.cs
+++ b/ExtraEnemyCustomization/EntryPoint.cs
@@ -7,12 +7,12 @@ using EEC.Managers.Assets;
 using EEC.Networking;
 using EEC.Utils.Integrations;
 using HarmonyLib;
+using Il2CppInterop.Runtime.Injection;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using UnhollowerRuntimeLib;
 
 namespace EEC
 {

--- a/ExtraEnemyCustomization/Events/MonoBehaviourEventHandler.cs
+++ b/ExtraEnemyCustomization/Events/MonoBehaviourEventHandler.cs
@@ -1,5 +1,5 @@
 ﻿using EEC.Attributes;
-using UnhollowerBaseLib.Attributes;
+using Il2CppInterop.Runtime.Attributes;
 using UnityEngine;
 
 namespace EEC.Events

--- a/ExtraEnemyCustomization/ExtraEnemyCustomization.csproj
+++ b/ExtraEnemyCustomization/ExtraEnemyCustomization.csproj
@@ -9,8 +9,8 @@
     <BIELibsFolder>$(GameFolder)/BepInEx/core</BIELibsFolder>
     <UnhollowedLibsFolder>$(GameFolder)/BepInEx/unhollowed</UnhollowedLibsFolder>
     <PluginsFolder>$(GameFolder)/BepInEx/plugins</PluginsFolder>
-    <MonoManagedFolder>$(GameFolder)/mono/Managed</MonoManagedFolder>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <CorLibsFolder>$(GameFolder)/dotnet/corlib</CorLibsFolder>
+    <TargetFramework>net6</TargetFramework>
     <LangVersion>Latest</LangVersion>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
     <Version>1.6.0</Version>
@@ -25,11 +25,9 @@
   <ItemGroup>
     <Reference Include="$(BIELibsFolder)/BepInEx.*.dll" Private="false" />
     <Reference Include="$(BIELibsFolder)/0Harmony.dll" Private="false" />
-    <Reference Include="$(BIELibsFolder)/UnhollowerBaseLib.dll" Private="false" />
-    <Reference Include="$(BIELibsFolder)/UnhollowerRuntimeLib.dll" Private="false" />
+    <Reference Include="$(BIELibsFolder)/Il2CppInterop.Runtime.dll" Private="false" />
     <Reference Include="$(BIELibsFolder)/SemanticVersioning.dll" Private="false" />
-    <Reference Include="$(MonoManagedFolder)/Microsoft.CSharp.dll" Private="false" />
-    <Reference Include="$(MonoManagedFolder)/System.Text.Json.dll" Private="false" />
+    <Reference Include="$(CorLibsFolder)/*.dll" Private="false" />
     <Reference Include="$(UnhollowedLibsFolder)/*.dll" Private="false" />
     <Reference Include="$(PluginsFolder)/GTFO-API.dll" Private="false" />
     <Reference Remove="$(UnhollowedLibsFolder)/Newtonsoft.Json.dll" />

--- a/ExtraEnemyCustomization/ExtraEnemyCustomization.csproj
+++ b/ExtraEnemyCustomization/ExtraEnemyCustomization.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <BIELibsFolder>$(GameFolder)/BepInEx/core</BIELibsFolder>
-    <UnhollowedLibsFolder>$(GameFolder)/BepInEx/unhollowed</UnhollowedLibsFolder>
+    <InteropLibsFolder>$(GameFolder)/BepInEx/interop</InteropLibsFolder>
     <PluginsFolder>$(GameFolder)/BepInEx/plugins</PluginsFolder>
     <CorLibsFolder>$(GameFolder)/dotnet/corlib</CorLibsFolder>
     <TargetFramework>net6</TargetFramework>
@@ -25,13 +25,14 @@
   <ItemGroup>
     <Reference Include="$(BIELibsFolder)/BepInEx.*.dll" Private="false" />
     <Reference Include="$(BIELibsFolder)/0Harmony.dll" Private="false" />
-    <Reference Include="$(BIELibsFolder)/Il2CppInterop.Runtime.dll" Private="false" />
+    <Reference Include="$(BIELibsFolder)/Il2CppInterop.*.dll" Private="false" />
     <Reference Include="$(BIELibsFolder)/SemanticVersioning.dll" Private="false" />
     <Reference Include="$(CorLibsFolder)/*.dll" Private="false" />
-    <Reference Include="$(UnhollowedLibsFolder)/*.dll" Private="false" />
+    <Reference Include="$(CorLibsFolder)/../System.Private.CoreLib.dll" Private="false" />
+    <Reference Include="$(InteropLibsFolder)/*.dll" Private="false" />
     <Reference Include="$(PluginsFolder)/GTFO-API.dll" Private="false" />
-    <Reference Remove="$(UnhollowedLibsFolder)/Newtonsoft.Json.dll" />
-    <Reference Remove="$(UnhollowedLibsFolder)/netstandard.dll" />
+    <Reference Remove="$(InteropLibsFolder)/Newtonsoft.Json.dll" />
+    <Reference Remove="$(InteropLibsFolder)/netstandard.dll" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ExtraEnemyCustomization/Managers/Assets/AssetCacheManager.cs
+++ b/ExtraEnemyCustomization/Managers/Assets/AssetCacheManager.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using Il2CppInterop.Runtime;
+using System.Collections.Generic;
 using System.IO;
-using UnhollowerRuntimeLib;
 using UnityEngine;
 
 namespace EEC.Managers.Assets

--- a/ExtraEnemyCustomization/Utils/EnemyAnimUtil.cs
+++ b/ExtraEnemyCustomization/Utils/EnemyAnimUtil.cs
@@ -1,10 +1,10 @@
 ﻿using EEC.Networking;
 using EEC.Networking.Events;
 using Enemies;
+using Il2CppInterop.Runtime;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using UnhollowerBaseLib;
 
 namespace EEC.Utils
 {

--- a/ExtraEnemyCustomization/Utils/EnemyAnimUtil.cs
+++ b/ExtraEnemyCustomization/Utils/EnemyAnimUtil.cs
@@ -2,6 +2,7 @@
 using EEC.Networking.Events;
 using Enemies;
 using Il2CppInterop.Runtime;
+using Il2CppInterop.Runtime.InteropTypes.Arrays;
 using System;
 using System.Collections.Generic;
 using System.Reflection;


### PR DESCRIPTION
## Context
BepInEx's mono domain will be replaced with CoreCLR which will now support .NET 6 and the BepInEx fork of Unhollower will be renamed to Il2CppInterop.

## Summary
Changes the necessary files and dependencies to build and run on the new CoreCLR domain

This PR will be undrafted when a proper build is available