### PR TITLE
Added HealthBar support to MarkerText

### DIFF
--- a/ExtraEnemyCustomization/EnemyCustomizations/Models/Handlers/MarkerTextHandler.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Models/Handlers/MarkerTextHandler.cs
@@ -1,4 +1,5 @@
 ﻿using EEC.Attributes;
+using EEC.Networking;
 using EEC.Utils.Unity;
 using Enemies;
 using Il2CppInterop.Runtime.Attributes;
@@ -15,6 +16,7 @@ namespace EEC.EnemyCustomizations.Models.Handlers
     {
         public EnemyAgent Agent;
         public NavMarker Marker;
+        public HealthBarFormat.Worker Worker;
         private string _baseText;
         private bool[] _hasFormat = null;
         private bool _shouldUpdateRainbow = false;
@@ -110,6 +112,10 @@ namespace EEC.EnemyCustomizations.Models.Handlers
 
             while (true)
             {
+                NetworkManager.EnemyHealthState.TryGetState(Agent.GlobalID, out var healthState);
+                var maxHealth = healthState.maxHealth;
+                var health = healthState.health;
+
                 for (int i = 1 /*Skips None*/; i < _valuesOfEnum.Length; i++)
                 {
                     if (!_hasFormat[i])
@@ -119,12 +125,13 @@ namespace EEC.EnemyCustomizations.Models.Handlers
                     {
                         MarkerFormatText.None => string.Empty,
                         MarkerFormatText.NAME => string.Empty,
-                        MarkerFormatText.HP => Agent.Damage.Health.ToString("0.00"),
-                        MarkerFormatText.HP_ROUND => Mathf.RoundToInt(Agent.Damage.Health).ToString(),
-                        MarkerFormatText.HP_MAX => Agent.Damage.HealthMax.ToString("0.00"),
-                        MarkerFormatText.HP_MAX_ROUND => Mathf.RoundToInt(Agent.Damage.HealthMax).ToString(),
-                        MarkerFormatText.HP_PERCENT => (Agent.Damage.Health / Agent.Damage.HealthMax * 100.0f).ToString("0.00"),
-                        MarkerFormatText.HP_PERCENT_ROUND => Mathf.RoundToInt(Agent.Damage.Health / Agent.Damage.HealthMax * 100.0f).ToString(),
+                        MarkerFormatText.HP => health.ToString("0.00"),
+                        MarkerFormatText.HP_ROUND => Mathf.RoundToInt(health).ToString(),
+                        MarkerFormatText.HP_MAX => maxHealth.ToString("0.00"),
+                        MarkerFormatText.HP_MAX_ROUND => Mathf.RoundToInt(maxHealth).ToString(),
+                        MarkerFormatText.HP_PERCENT => (health / maxHealth * 100.0f).ToString("0.00"),
+                        MarkerFormatText.HP_PERCENT_ROUND => Mathf.RoundToInt(health / maxHealth * 100.0f).ToString(),
+                        MarkerFormatText.HP_BAR => Worker.BuildString(maxHealth, health),
                         MarkerFormatText.GAMING => ColorUtility.ToHtmlStringRGB(_rainbow),
                         _ => string.Empty,
                     };
@@ -163,6 +170,7 @@ namespace EEC.EnemyCustomizations.Models.Handlers
         {
             Agent = null;
             Marker = null;
+            Worker = null;
             _baseText = null;
             _hasFormat = null;
         }
@@ -178,6 +186,7 @@ namespace EEC.EnemyCustomizations.Models.Handlers
         HP_MAX_ROUND,
         HP_PERCENT,
         HP_PERCENT_ROUND,
+        HP_BAR,
         GAMING //yes
     }
 }

--- a/ExtraEnemyCustomization/EnemyCustomizations/Models/MarkerCustom.cs
+++ b/ExtraEnemyCustomization/EnemyCustomizations/Models/MarkerCustom.cs
@@ -4,6 +4,7 @@ using EEC.Managers.Assets;
 using EEC.Utils;
 using Enemies;
 using System;
+using System.Text;
 using UnityEngine;
 
 namespace EEC.EnemyCustomizations.Models
@@ -13,6 +14,7 @@ namespace EEC.EnemyCustomizations.Models
         public string SpriteName { get; set; } = string.Empty;
         public Color MarkerColor { get; set; } = new Color(0.8235f, 0.1843f, 0.1176f);
         public string MarkerText { get; set; } = string.Empty;
+        public HealthBarFormat MarkerTextHealthBarFormat { get; set; } = new();
         public bool ShowDistance { get; set; } = false;
         public bool BlinkIn { get; set; } = false;
         public bool Blink { get; set; } = false;
@@ -91,6 +93,7 @@ namespace EEC.EnemyCustomizations.Models
                     {
                         handler = marker.gameObject.AddComponent<MarkerTextHandler>();
                         handler.Agent = agent;
+                        handler.Worker = MarkerTextHealthBarFormat.CreateWorker();
                     }
 
                     handler.Marker = marker;
@@ -132,6 +135,68 @@ namespace EEC.EnemyCustomizations.Models
                         CoroutineManager.BlinkIn(marker.m_enemySubObj.gameObject, time);
                     }
                 }
+            }
+        }
+    }
+
+    public sealed class HealthBarFormat
+    {
+        public int Count { get; set; } = 8;
+        public string FilledBarText { get; set; } = "|";
+        public string EmptyBarText { get; set; } = " ";
+
+        public Worker CreateWorker()
+        {
+            return new Worker()
+            {
+                Count = Count,
+                FilledBarText = FilledBarText,
+                EmptyBarText = EmptyBarText
+            };
+        }
+
+        public sealed class Worker
+        {
+            public int Count;
+            public string FilledBarText;
+            public string EmptyBarText;
+
+            private StringBuilder _stringBuilder;
+            private int _lastFilledBar = -1;
+            private string _lastBarText = string.Empty;
+
+            public string BuildString(float maxHealth, float health)
+            {
+                var filledBarCount = Mathf.RoundToInt(Mathf.Lerp(0, Count, health / maxHealth));
+                if (filledBarCount == _lastFilledBar)
+                {
+                    return _lastBarText;
+                }
+
+                _lastFilledBar = filledBarCount;
+                if (_stringBuilder == null)
+                {
+                    _stringBuilder = new();
+                }
+                else
+                {
+                    _stringBuilder.Clear();
+                }
+
+                for (int i = 0; i < Count; i++)
+                {
+                    if (i < filledBarCount)
+                    {
+                        _stringBuilder.Append(FilledBarText);
+                    }
+                    else
+                    {
+                        _stringBuilder.Append(EmptyBarText);
+                    }
+                }
+
+                _lastBarText = _stringBuilder.ToString();
+                return _lastBarText;
             }
         }
     }

--- a/ExtraEnemyCustomization/Events/EnemyDamageEvents.cs
+++ b/ExtraEnemyCustomization/Events/EnemyDamageEvents.cs
@@ -4,6 +4,7 @@ using Enemies;
 namespace EEC.Events
 {
     public delegate void EnemyTakeDamageHandler(EnemyAgent enemyAgent, Agent inflictor, float damage);
+    public delegate void EnemyHealthUpdateHandler(EnemyAgent enemyAgent, float maxHealth, float health);
 
     public static class EnemyDamageEvents
     {
@@ -14,6 +15,8 @@ namespace EEC.Events
         public static event EnemyTakeDamageHandler BulletDamage;
 
         public static event EnemyTakeDamageHandler ExplosionDamage;
+
+        public static event EnemyHealthUpdateHandler HealthUpdated;
 
         internal static void OnDamage(EnemyAgent enemyAgent, Agent inflictor, float damage)
         {
@@ -33,6 +36,11 @@ namespace EEC.Events
         internal static void OnExplosionDamage(EnemyAgent enemyAgent, Agent inflictor, float damage)
         {
             ExplosionDamage?.Invoke(enemyAgent, inflictor, damage);
+        }
+
+        internal static void OnHealthUpdated(EnemyAgent enemyAgent, float maxHealth, float health)
+        {
+            HealthUpdated?.Invoke(enemyAgent, maxHealth, health);
         }
     }
 }

--- a/ExtraEnemyCustomization/Networking/Replicators/EnemyHealthInfoReplicator.cs
+++ b/ExtraEnemyCustomization/Networking/Replicators/EnemyHealthInfoReplicator.cs
@@ -1,0 +1,32 @@
+﻿using Enemies;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace EEC.Networking.Replicators
+{
+    public sealed class EnemyHealthInfoReplicator : StateReplicator<EnemyHealthInfoReplicator.State>
+    {
+        public override bool ClearOnLevelCleanup => true;
+
+        public override string GUID => "EHI";
+
+        public void UpdateInfo(EnemyAgent agent)
+        {
+            SetState(agent.GlobalID, new State()
+            {
+                maxHealth = agent.Damage.HealthMax,
+                health = Mathf.Max(0.0f, agent.Damage.Health)
+            });
+        }
+
+        public struct State
+        {
+            public float maxHealth;
+            public float health;
+        }
+    }
+}


### PR DESCRIPTION
```
MarkerCustom...

      "MarkerColor": "#d22f1e", //Color for Marker: Official one is #d22f1e
      "MarkerText": "::BIO_PROBE::\n[[HP_BAR]]", //Display text for Marker
      "MarkerTextHealthBarFormat": {
        "Count": 10,
        "FilledBarText": "|",
        "EmptyBarText": " "
      },
```

![image](https://user-images.githubusercontent.com/6457392/175755259-dd0f1df3-22c1-4aa9-bbb2-d2c6686c9cc3.png)
